### PR TITLE
add possibility to add options to the update notify curl request

### DIFF
--- a/blueprints_update.sh
+++ b/blueprints_update.sh
@@ -90,7 +90,7 @@ function _persistent_notification_create
 	if [ "${_blueprints_update_notify}" == "true" ]
 	then
 		_blueprint_update_debug "notification create: [${notification_id}] [${notification_message}]"
-		curl --silent -X POST -H "Authorization: Bearer ${_blueprints_update_token}" -H "Content-Type: application/json" -d "{ \"notification_id\": \"bu:${notification_id}\", \"title\": \"Blueprints Update\", \"message\": \"${notification_message}\" }" "${_blueprints_update_server}/api/services/persistent_notification/create" >/dev/null
+		curl ${_blueprints_update_curl_options} -X POST -H "Authorization: Bearer ${_blueprints_update_token}" -H "Content-Type: application/json" -d "{ \"notification_id\": \"bu:${notification_id}\", \"title\": \"Blueprints Update\", \"message\": \"${notification_message}\" }" "${_blueprints_update_server}/api/services/persistent_notification/create" >/dev/null
 	else
 		_blueprint_update_info "notifications not enabled"
 	fi
@@ -104,7 +104,7 @@ function _persistent_notification_dismiss
 	if [ "${_blueprints_update_notify}" == "true" ]
 	then
 		_blueprint_update_debug "notification dismiss: [${notification_id}]"
-		curl --silent -X POST -H "Authorization: Bearer ${_blueprints_update_token}" -H "Content-Type: application/json" -d "{ \"notification_id\": \"bu:${notification_id}\" }" "${_blueprints_update_server}/api/services/persistent_notification/dismiss" >/dev/null
+		curl ${_blueprints_update_curl_options} -X POST -H "Authorization: Bearer ${_blueprints_update_token}" -H "Content-Type: application/json" -d "{ \"notification_id\": \"bu:${notification_id}\" }" "${_blueprints_update_server}/api/services/persistent_notification/dismiss" >/dev/null
 	else
 		_blueprint_update_info "notifications not enabled"
 	fi
@@ -168,6 +168,11 @@ then
 	then
 		_blueprint_update_info "config file found, but _blueprints_update_token is not set"
 		_blueprints_update_notify="false"
+	fi
+
+ 	if [ "${_blueprints_update_curl_options}" == "" ]
+	then
+		_blueprints_update_curl_options="--silent"
 	fi
 
 	if [ "${_blueprints_update_auto_update,,}" == "true" ]


### PR DESCRIPTION
I have the issue that i use the local ip as update server but couldn't send the notifications because of the invalid ssl certificate for the ip.

Therefore i want an possibilty to add options to the notify curl request.

I have changed the code that  it`s update save but you could set options via the config file
e.g. adding to the .conf to disable the ssl verification
```
_blueprints_update_curl_options="--insecure --silent"
````

if the option isn't set in the .conf its per default set to "--silent".

Setting the options through the config file also makes it possible to easier debug the request if the "--silent" is removed.


